### PR TITLE
Started adding unit tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -131,6 +131,32 @@
                 </configuration>
             </plugin>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.7</version>
+                <configuration>
+                    <skipTests>true</skipTests>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.scalatest</groupId>
+                <artifactId>scalatest-maven-plugin</artifactId>
+                <version>1.0</version>
+                <configuration>
+                    <reportsDirectory>${project.build.directory}/surefire-reports</reportsDirectory>
+                    <junitxml>.</junitxml>
+                    <filereports>tests.txt</filereports>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>test</id>
+                        <goals>
+                            <goal>test</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <artifactId>maven-assembly-plugin</artifactId>
                 <version>2.4</version>
                 <configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
         <scala.artifact.version>2.11</scala.artifact.version>
         <scala.version>${scala.artifact.version}.7</scala.version>
         <akka.version>2.4.9</akka.version>
-        <wookiee.core.version>1.2.3</wookiee.core.version>
+        <wookiee.core.version>1.2.5</wookiee.core.version>
     </properties>
 
     <groupId>com.webtrends</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -97,13 +97,13 @@
         <dependency>
             <groupId>org.scalatest</groupId>
             <artifactId>scalatest_${scala.artifact.version}</artifactId>
-            <version>2.2.6</version>
+            <version>3.0.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.scalacheck</groupId>
             <artifactId>scalacheck_${scala.artifact.version}</artifactId>
-            <version>1.12.5</version>
+            <version>1.13.4</version>
             <scope>test</scope>
         </dependency>
 

--- a/src/main/scala/com/webtrends/harness/component/akkahttp/AkkaHttpBase.scala
+++ b/src/main/scala/com/webtrends/harness/component/akkahttp/AkkaHttpBase.scala
@@ -3,14 +3,11 @@ package com.webtrends.harness.component.akkahttp
 import akka.http.scaladsl.model.StatusCodes._
 import akka.http.scaladsl.server.Directives.{path => p, _}
 import akka.http.scaladsl.server._
-import com.webtrends.harness.command.{BaseCommandResponse, CommandBean}
-import com.webtrends.harness.component.akkahttp.AkkaHttpBase.CommandLike
-import com.webtrends.harness.logging.Logger
+import com.webtrends.harness.command.{BaseCommandResponse, CommandBean, BaseCommand}
 import de.heikoseeberger.akkahttpjson4s.Json4sSupport._
 import org.json4s.ext.JodaTimeSerializers
 import org.json4s.{DefaultFormats, jackson}
 
-import scala.concurrent.Future
 import scala.util.{Failure, Success}
 
 case class AkkaHttpCommandResponse[T](data: Option[T], responseType: String = "_") extends BaseCommandResponse[T]
@@ -22,7 +19,7 @@ trait AkkaHttpEntity
 trait AkkaHttpAuth
 
 trait AkkaHttpBase {
-  this: CommandLike =>
+  this: BaseCommand =>
 
   implicit val serialization = jackson.Serialization
   implicit val formats       = DefaultFormats ++ JodaTimeSerializers.all
@@ -77,10 +74,4 @@ object AkkaHttpBase {
   val Params = "params"
   val Auth = "auth"
   val Entity = "entity"
-
-  type CommandLike = {
-    def path: String
-    def execute[T:Manifest](bean: Option[CommandBean]) : Future[BaseCommandResponse[T]]
-    val log : Logger
-  }
 }

--- a/src/main/scala/com/webtrends/harness/component/akkahttp/verbs/AkkaHttpDelete.scala
+++ b/src/main/scala/com/webtrends/harness/component/akkahttp/verbs/AkkaHttpDelete.scala
@@ -1,11 +1,13 @@
-package com.webtrends.harness.component.akkahttp
+package com.webtrends.harness.component.akkahttp.verbs
 
 import akka.http.scaladsl.server.Directives.{path => p, _}
 import akka.http.scaladsl.server._
-import com.webtrends.harness.command.{Command, CommandBean}
+import com.webtrends.harness.command.CommandBean
+import com.webtrends.harness.component.akkahttp.AkkaHttpBase
+import com.webtrends.harness.component.akkahttp.AkkaHttpBase.CommandLike
 
 trait AkkaHttpDelete extends AkkaHttpBase {
-  this: Command =>
+  this: CommandLike =>
   override protected def commandInnerDirective[T <: AnyRef : Manifest](bean: CommandBean): Route = delete {
     super.commandInnerDirective(bean)
   }

--- a/src/main/scala/com/webtrends/harness/component/akkahttp/verbs/AkkaHttpDelete.scala
+++ b/src/main/scala/com/webtrends/harness/component/akkahttp/verbs/AkkaHttpDelete.scala
@@ -2,12 +2,11 @@ package com.webtrends.harness.component.akkahttp.verbs
 
 import akka.http.scaladsl.server.Directives.{path => p, _}
 import akka.http.scaladsl.server._
-import com.webtrends.harness.command.CommandBean
+import com.webtrends.harness.command.{CommandBean, BaseCommand}
 import com.webtrends.harness.component.akkahttp.AkkaHttpBase
-import com.webtrends.harness.component.akkahttp.AkkaHttpBase.CommandLike
 
 trait AkkaHttpDelete extends AkkaHttpBase {
-  this: CommandLike =>
+  this: BaseCommand =>
   override protected def commandInnerDirective[T <: AnyRef : Manifest](bean: CommandBean): Route = delete {
     super.commandInnerDirective(bean)
   }

--- a/src/main/scala/com/webtrends/harness/component/akkahttp/verbs/AkkaHttpGet.scala
+++ b/src/main/scala/com/webtrends/harness/component/akkahttp/verbs/AkkaHttpGet.scala
@@ -2,12 +2,11 @@ package com.webtrends.harness.component.akkahttp.verbs
 
 import akka.http.scaladsl.server.Directives.{path => p, _}
 import akka.http.scaladsl.server._
-import com.webtrends.harness.command.CommandBean
+import com.webtrends.harness.command.{CommandBean, BaseCommand}
 import com.webtrends.harness.component.akkahttp.AkkaHttpBase
-import com.webtrends.harness.component.akkahttp.AkkaHttpBase.CommandLike
 
 trait AkkaHttpGet extends AkkaHttpBase {
-  this: CommandLike =>
+  this: BaseCommand =>
   override protected def commandInnerDirective[T <: AnyRef : Manifest](bean: CommandBean): Route = get {
     super.commandInnerDirective(bean)
   }

--- a/src/main/scala/com/webtrends/harness/component/akkahttp/verbs/AkkaHttpGet.scala
+++ b/src/main/scala/com/webtrends/harness/component/akkahttp/verbs/AkkaHttpGet.scala
@@ -1,11 +1,13 @@
-package com.webtrends.harness.component.akkahttp
+package com.webtrends.harness.component.akkahttp.verbs
 
 import akka.http.scaladsl.server.Directives.{path => p, _}
 import akka.http.scaladsl.server._
-import com.webtrends.harness.command.{Command, CommandBean}
+import com.webtrends.harness.command.CommandBean
+import com.webtrends.harness.component.akkahttp.AkkaHttpBase
+import com.webtrends.harness.component.akkahttp.AkkaHttpBase.CommandLike
 
 trait AkkaHttpGet extends AkkaHttpBase {
-  this: Command =>
+  this: CommandLike =>
   override protected def commandInnerDirective[T <: AnyRef : Manifest](bean: CommandBean): Route = get {
     super.commandInnerDirective(bean)
   }

--- a/src/main/scala/com/webtrends/harness/component/akkahttp/verbs/AkkaHttpPost.scala
+++ b/src/main/scala/com/webtrends/harness/component/akkahttp/verbs/AkkaHttpPost.scala
@@ -2,14 +2,13 @@ package com.webtrends.harness.component.akkahttp.verbs
 
 import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server.Route
-import com.webtrends.harness.command.CommandBean
+import com.webtrends.harness.command.{CommandBean, BaseCommand}
 import com.webtrends.harness.component.akkahttp.AkkaHttpBase
-import com.webtrends.harness.component.akkahttp.AkkaHttpBase.CommandLike
 import de.heikoseeberger.akkahttpjson4s.Json4sSupport._
 import org.json4s.JObject
 
 trait AkkaHttpPost extends AkkaHttpBase {
-  this: CommandLike =>
+  this: BaseCommand =>
 
   override protected def commandInnerDirective[T <: AnyRef : Manifest](bean: CommandBean): Route = post {
     entity(as[JObject]) { e =>

--- a/src/main/scala/com/webtrends/harness/component/akkahttp/verbs/AkkaHttpPost.scala
+++ b/src/main/scala/com/webtrends/harness/component/akkahttp/verbs/AkkaHttpPost.scala
@@ -1,13 +1,15 @@
-package com.webtrends.harness.component.akkahttp
+package com.webtrends.harness.component.akkahttp.verbs
 
 import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server.Route
-import com.webtrends.harness.command.{Command, CommandBean}
+import com.webtrends.harness.command.CommandBean
+import com.webtrends.harness.component.akkahttp.AkkaHttpBase
+import com.webtrends.harness.component.akkahttp.AkkaHttpBase.CommandLike
 import de.heikoseeberger.akkahttpjson4s.Json4sSupport._
 import org.json4s.JObject
 
 trait AkkaHttpPost extends AkkaHttpBase {
-  this: Command =>
+  this: CommandLike =>
 
   override protected def commandInnerDirective[T <: AnyRef : Manifest](bean: CommandBean): Route = post {
     entity(as[JObject]) { e =>

--- a/src/main/scala/com/webtrends/harness/component/akkahttp/verbs/AkkaHttpUpload.scala
+++ b/src/main/scala/com/webtrends/harness/component/akkahttp/verbs/AkkaHttpUpload.scala
@@ -1,12 +1,14 @@
-package com.webtrends.harness.component.akkahttp
+package com.webtrends.harness.component.akkahttp.verbs
 
 import akka.http.scaladsl.server.Route
 import akka.http.scaladsl.server.directives.FileUploadDirectives.uploadedFile
-import com.webtrends.harness.command.{Command, CommandBean}
+import com.webtrends.harness.command.CommandBean
+import com.webtrends.harness.component.akkahttp.AkkaHttpBase
+import com.webtrends.harness.component.akkahttp.AkkaHttpBase.CommandLike
 
 
 trait AkkaHttpUpload extends AkkaHttpBase {
-  this: Command =>
+  this: CommandLike =>
 
   override protected def commandInnerDirective[T <: AnyRef : Manifest](bean: CommandBean): Route =
     uploadedFile("csv") { case (fileInfo, file) =>

--- a/src/main/scala/com/webtrends/harness/component/akkahttp/verbs/AkkaHttpUpload.scala
+++ b/src/main/scala/com/webtrends/harness/component/akkahttp/verbs/AkkaHttpUpload.scala
@@ -2,13 +2,12 @@ package com.webtrends.harness.component.akkahttp.verbs
 
 import akka.http.scaladsl.server.Route
 import akka.http.scaladsl.server.directives.FileUploadDirectives.uploadedFile
-import com.webtrends.harness.command.CommandBean
+import com.webtrends.harness.command.{CommandBean, BaseCommand}
 import com.webtrends.harness.component.akkahttp.AkkaHttpBase
-import com.webtrends.harness.component.akkahttp.AkkaHttpBase.CommandLike
 
 
 trait AkkaHttpUpload extends AkkaHttpBase {
-  this: CommandLike =>
+  this: BaseCommand =>
 
   override protected def commandInnerDirective[T <: AnyRef : Manifest](bean: CommandBean): Route =
     uploadedFile("csv") { case (fileInfo, file) =>

--- a/src/test/scala/com/webtrends/harness/component/akkahttp/verbs/AkkaHttpGetTest.scala
+++ b/src/test/scala/com/webtrends/harness/component/akkahttp/verbs/AkkaHttpGetTest.scala
@@ -4,15 +4,15 @@ import akka.http.scaladsl.model.{StatusCode, StatusCodes}
 import akka.http.scaladsl.server.Route
 import akka.http.scaladsl.server.RouteConcatenation._
 import akka.http.scaladsl.testkit.ScalatestRouteTest
-import com.webtrends.harness.command.{BaseCommandResponse, CommandBean, CommandResponse}
+import com.webtrends.harness.command.{BaseCommandResponse, CommandBean, BaseCommand, CommandResponse}
 import com.webtrends.harness.logging.Logger
 import org.scalatest.prop.PropertyChecks
 import org.scalatest.{FunSuite, MustMatchers}
 
 import scala.concurrent.Future
 
-trait TestCommand {
-  val log = Logger("test logger")
+trait TestBaseCommand extends BaseCommand {
+  override val log = Logger("test logger")
   def path: String
   def execute[T:Manifest](bean: Option[CommandBean]) : Future[BaseCommandResponse[T]]
 }
@@ -22,7 +22,7 @@ class AkkaHttpGetTest extends FunSuite with PropertyChecks with MustMatchers wit
   test("should return InternalServerError when command fails") {
     var routes = Set.empty[Route]
 
-    val getCommand = new AkkaHttpGet with TestCommand {
+    val getCommand = new AkkaHttpGet with TestBaseCommand {
       override def path: String = "test"
       override def addRoute(r: Route): Unit = routes += r
       override def execute[T : Manifest](bean: Option[CommandBean]): Future[BaseCommandResponse[T]] =
@@ -37,7 +37,7 @@ class AkkaHttpGetTest extends FunSuite with PropertyChecks with MustMatchers wit
   test("should respond with NoContent when command respond with no data") {
     var routes = Set.empty[Route]
 
-    val getCommand = new AkkaHttpGet with TestCommand {
+    val getCommand = new AkkaHttpGet with TestBaseCommand {
       override def path: String = "test"
       override def addRoute(r: Route): Unit = routes += r
       override def execute[T : Manifest](bean: Option[CommandBean]): Future[BaseCommandResponse[T]] =

--- a/src/test/scala/com/webtrends/harness/component/akkahttp/verbs/AkkaHttpGetTest.scala
+++ b/src/test/scala/com/webtrends/harness/component/akkahttp/verbs/AkkaHttpGetTest.scala
@@ -1,0 +1,52 @@
+package com.webtrends.harness.component.akkahttp.verbs
+
+import akka.http.scaladsl.model.{StatusCode, StatusCodes}
+import akka.http.scaladsl.server.Route
+import akka.http.scaladsl.server.RouteConcatenation._
+import akka.http.scaladsl.testkit.ScalatestRouteTest
+import com.webtrends.harness.command.{BaseCommandResponse, CommandBean, CommandResponse}
+import com.webtrends.harness.logging.Logger
+import org.scalatest.prop.PropertyChecks
+import org.scalatest.{FunSuite, MustMatchers}
+
+import scala.concurrent.Future
+
+trait TestCommand {
+  val log = Logger("test logger")
+  def path: String
+  def execute[T:Manifest](bean: Option[CommandBean]) : Future[BaseCommandResponse[T]]
+}
+
+class AkkaHttpGetTest extends FunSuite with PropertyChecks with MustMatchers with ScalatestRouteTest {
+
+  test("should return InternalServerError when command fails") {
+    var routes = Set.empty[Route]
+
+    val getCommand = new AkkaHttpGet with TestCommand {
+      override def path: String = "test"
+      override def addRoute(r: Route): Unit = routes += r
+      override def execute[T : Manifest](bean: Option[CommandBean]): Future[BaseCommandResponse[T]] =
+        Future.failed(new Exception("error"))
+    }
+
+    Get("/test") ~> routes.reduceLeft(_ ~ _) ~> check {
+      status mustEqual StatusCodes.InternalServerError
+    }
+  }
+
+  test("should respond with NoContent when command respond with no data") {
+    var routes = Set.empty[Route]
+
+    val getCommand = new AkkaHttpGet with TestCommand {
+      override def path: String = "test"
+      override def addRoute(r: Route): Unit = routes += r
+      override def execute[T : Manifest](bean: Option[CommandBean]): Future[BaseCommandResponse[T]] =
+        Future.successful(CommandResponse(None))
+    }
+
+    Get("/test") ~> routes.reduceLeft(_ ~ _) ~> check {
+      status mustEqual StatusCodes.NoContent
+    }
+  }
+
+}


### PR DESCRIPTION
Previously, `AkkaHttpBase` required itself to be a wookiee `Command`. Now `AkkaHttpBase` require itself to be a `CommandLike`. Which is essentially defined to have a shape of a wookiee command

```scala
  type CommandLike = {
    def path: String
    def execute[T:Manifest](bean: Option[CommandBean]) : Future[BaseCommandResponse[T]]
    val log : Logger
  }
```

This will allow us to unit test without having to spin up wookiee/akka actors