### PR TITLE
Refactor of Packages, Websocket Support

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -8,6 +8,7 @@ wookiee-akka-http {
 
   external-server {
     interface = 0.0.0.0
+    websocket-port = 8081
     http-port = 8082
   }
 

--- a/src/main/scala/com/webtrends/harness/component/akkahttp/AkkaHttp.scala
+++ b/src/main/scala/com/webtrends/harness/component/akkahttp/AkkaHttp.scala
@@ -8,55 +8,17 @@ import akka.actor.ActorRef
 import akka.http.scaladsl.settings.ServerSettings
 import com.typesafe.config.Config
 import com.webtrends.harness.component.Component
+import com.webtrends.harness.component.akkahttp.routes.{AkkaHttpUnbind, ExternalAkkaHttpActor, InternalAkkaHttpActor}
 import com.webtrends.harness.utils.ConfigUtil
 
 trait AkkaHttp {
   this: Component =>
 
-  val settings = AkkaHttpSettings(config)
 
-  var internalAkkaHttpRef: Option[ActorRef] = None
-  var externalAkkaHttpRef: Option[ActorRef] = None
-
-  def startAkkaHttp() = {
-    internalAkkaHttpRef = Some(context.actorOf(InternalAkkaHttpActor.props(settings.internal), AkkaHttp.InternalAkkaHttpName))
-    if (settings.external.enabled) {
-      externalAkkaHttpRef = Some(context.actorOf(ExternalAkkaHttpActor.props(settings.external), AkkaHttp.externalAkkaHttpName))
-    }
-  }
-
-  def stopAkkaHttp() = {
-    Seq(internalAkkaHttpRef, externalAkkaHttpRef).flatten.foreach(_ ! AkkaHttpUnbind)
-  }
 
 }
 
-final case class InternalAkkaHttpSettings(interface: String, port: Int, serverSettings: ServerSettings)
-final case class ExternalAkkaHttpSettings(enabled: Boolean, interface: String, port: Int, serverSettings: ServerSettings)
-final case class AkkaHttpSettings(internal: InternalAkkaHttpSettings, external: ExternalAkkaHttpSettings)
 
-object AkkaHttpSettings {
-  def apply(config: Config): AkkaHttpSettings = {
-    val internalPort = ConfigUtil.getDefaultValue("wookiee-akka-http.internal-server.http-port", config.getInt, 8080)
-    val internalInterface = ConfigUtil.getDefaultValue("wookiee-akka-http.internal-server.interface", config.getString, "0.0.0.0")
 
-    val externalServerEnabled = ConfigUtil.getDefaultValue(
-      "wookiee-akka-http.external-server.enabled", config.getBoolean, false)
-    val externalPort = ConfigUtil.getDefaultValue(
-      "wookiee-akka-http.external-server.http-port", config.getInt, 8082)
-    val externalInterface = ConfigUtil.getDefaultValue(
-      "wookiee-akka-http.external-server.interface", config.getString, "0.0.0.0")
 
-    val serverSettings = ServerSettings(config)
 
-    AkkaHttpSettings(
-      InternalAkkaHttpSettings(internalInterface, internalPort, serverSettings),
-      ExternalAkkaHttpSettings(externalServerEnabled, externalInterface, externalPort, serverSettings)
-    )
-  }
-}
-
-object AkkaHttp {
-  val externalAkkaHttpName = "ExternalAkkaHttp"
-  val InternalAkkaHttpName = "InternalAkkaHttp"
-}

--- a/src/main/scala/com/webtrends/harness/component/akkahttp/AkkaHttpManager.scala
+++ b/src/main/scala/com/webtrends/harness/component/akkahttp/AkkaHttpManager.scala
@@ -4,11 +4,34 @@
  */
 package com.webtrends.harness.component.akkahttp
 
+import akka.actor.ActorRef
+import akka.http.scaladsl.settings.ServerSettings
+import com.typesafe.config.Config
 import com.webtrends.harness.component.Component
+import com.webtrends.harness.component.akkahttp.routes.{AkkaHttpUnbind, ExternalAkkaHttpActor, InternalAkkaHttpActor, WebsocketAkkaHttpActor}
+import com.webtrends.harness.utils.ConfigUtil
 
 case class AkkaHttpMessage()
 
 class AkkaHttpManager(name:String) extends Component(name) with AkkaHttp {
+  val settings = AkkaHttpSettings(config)
+
+  var internalAkkaHttpRef: Option[ActorRef] = None
+  var externalAkkaHttpRef: Option[ActorRef] = None
+  var wsAkkaHttpRef: Option[ActorRef] = None
+
+  def startAkkaHttp() = {
+    internalAkkaHttpRef = Some(context.actorOf(InternalAkkaHttpActor.props(settings.internal), AkkaHttpManager.InternalAkkaHttpName))
+    if (settings.external.enabled) {
+      externalAkkaHttpRef = Some(context.actorOf(ExternalAkkaHttpActor.props(settings.external), AkkaHttpManager.ExternalAkkaHttpName))
+      wsAkkaHttpRef = Some(context.actorOf(WebsocketAkkaHttpActor.props(settings.ws), AkkaHttpManager.WebsocketAkkaHttpName))
+    }
+  }
+
+  def stopAkkaHttp() = {
+    Seq(internalAkkaHttpRef, externalAkkaHttpRef, wsAkkaHttpRef).flatten.foreach(_ ! AkkaHttpUnbind)
+  }
+
   /**
    * We add super.receive because if you override the receive message from the component
    * and then do not include super.receive it will not handle messages from the
@@ -41,4 +64,40 @@ class AkkaHttpManager(name:String) extends Component(name) with AkkaHttp {
     super.stop
   }
 
+}
+
+object AkkaHttpManager {
+  val ExternalAkkaHttpName = "ExternalAkkaHttp"
+  val InternalAkkaHttpName = "InternalAkkaHttp"
+  val WebsocketAkkaHttpName = "WebsocketAkkaHttp"
+}
+
+final case class InternalAkkaHttpSettings(interface: String, port: Int, serverSettings: ServerSettings)
+final case class ExternalAkkaHttpSettings(enabled: Boolean, interface: String, port: Int, serverSettings: ServerSettings)
+final case class WebsocketAkkaHttpSettings(enabled: Boolean, interface: String, port: Int, serverSettings: ServerSettings)
+final case class AkkaHttpSettings(internal: InternalAkkaHttpSettings, external: ExternalAkkaHttpSettings,
+                                  ws: WebsocketAkkaHttpSettings)
+
+object AkkaHttpSettings {
+  def apply(config: Config): AkkaHttpSettings = {
+    val internalPort = ConfigUtil.getDefaultValue("wookiee-akka-http.internal-server.http-port", config.getInt, 8080)
+    val internalInterface = ConfigUtil.getDefaultValue("wookiee-akka-http.internal-server.interface", config.getString, "0.0.0.0")
+
+    val externalServerEnabled = ConfigUtil.getDefaultValue(
+      "wookiee-akka-http.external-server.enabled", config.getBoolean, false)
+    val wsPort = ConfigUtil.getDefaultValue(
+      "wookiee-akka-http.external-server.websocket-port", config.getInt, 8081)
+    val externalPort = ConfigUtil.getDefaultValue(
+      "wookiee-akka-http.external-server.http-port", config.getInt, 8082)
+    val externalInterface = ConfigUtil.getDefaultValue(
+      "wookiee-akka-http.external-server.interface", config.getString, "0.0.0.0")
+
+    val serverSettings = ServerSettings(config)
+
+    AkkaHttpSettings(
+      InternalAkkaHttpSettings(internalInterface, internalPort, serverSettings),
+      ExternalAkkaHttpSettings(externalServerEnabled, externalInterface, externalPort, serverSettings),
+      WebsocketAkkaHttpSettings(externalServerEnabled, externalInterface, wsPort, serverSettings)
+    )
+  }
 }

--- a/src/main/scala/com/webtrends/harness/component/akkahttp/directives/AkkaHttpInternal.scala
+++ b/src/main/scala/com/webtrends/harness/component/akkahttp/directives/AkkaHttpInternal.scala
@@ -2,7 +2,8 @@ package com.webtrends.harness.component.akkahttp.directives
 
 import akka.http.scaladsl.server.Route
 import com.webtrends.harness.command.BaseCommand
-import com.webtrends.harness.component.akkahttp.{AkkaHttpBase, InternalAkkaHttpRouteContainer}
+import com.webtrends.harness.component.akkahttp.AkkaHttpBase
+import com.webtrends.harness.component.akkahttp.routes.InternalAkkaHttpRouteContainer
 
 trait AkkaHttpInternal extends AkkaHttpBase {
   this: BaseCommand =>

--- a/src/main/scala/com/webtrends/harness/component/akkahttp/routes/ExternalAkkaHttpActor.scala
+++ b/src/main/scala/com/webtrends/harness/component/akkahttp/routes/ExternalAkkaHttpActor.scala
@@ -1,4 +1,4 @@
-package com.webtrends.harness.component.akkahttp
+package com.webtrends.harness.component.akkahttp.routes
 
 import akka.actor.Props
 import akka.http.scaladsl.Http
@@ -9,6 +9,7 @@ import akka.stream.ActorMaterializer
 import akka.stream.scaladsl.Sink
 import com.webtrends.harness.app.HActor
 import com.webtrends.harness.component.StopComponent
+import com.webtrends.harness.component.akkahttp.ExternalAkkaHttpSettings
 
 import scala.util.{Failure, Success}
 
@@ -19,11 +20,11 @@ object ExternalAkkaHttpActor {
 }
 
 class ExternalAkkaHttpActor(port: Int, interface: String, settings: ServerSettings) extends HActor {
-
   implicit val system = context.system
   implicit val executionContext = context.dispatcher
   implicit val materializer = ActorMaterializer()
 
+  def serverName = "akka-http external-server"
   val serverSource = Http().bind(interface, port, settings = settings)
 
   val bindingFuture = serverSource
@@ -32,7 +33,7 @@ class ExternalAkkaHttpActor(port: Int, interface: String, settings: ServerSettin
 
   bindingFuture.onComplete {
     case Success(s) =>
-      log.info(s"akka-http external-server bound to port $port on interface $interface")
+      log.info(s"$serverName bound to port $port on interface $interface")
     case Failure(f) =>
       log.error(s"Failed to bind akka-http external-server: $f")
   }

--- a/src/main/scala/com/webtrends/harness/component/akkahttp/routes/ExternalAkkaHttpRouteContainer.scala
+++ b/src/main/scala/com/webtrends/harness/component/akkahttp/routes/ExternalAkkaHttpRouteContainer.scala
@@ -1,4 +1,4 @@
-package com.webtrends.harness.component.akkahttp
+package com.webtrends.harness.component.akkahttp.routes
 
 import java.util.Collections
 

--- a/src/main/scala/com/webtrends/harness/component/akkahttp/routes/InternalAkkaHttpActor.scala
+++ b/src/main/scala/com/webtrends/harness/component/akkahttp/routes/InternalAkkaHttpActor.scala
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2014. Webtrends (http://www.webtrends.com)
  */
-package com.webtrends.harness.component.akkahttp
+package com.webtrends.harness.component.akkahttp.routes
 
 import akka.actor.Props
 import akka.http.scaladsl.Http
@@ -14,6 +14,7 @@ import akka.stream.ActorMaterializer
 import akka.stream.scaladsl.Sink
 import com.webtrends.harness.HarnessConstants
 import com.webtrends.harness.app.{HActor, Harness}
+import com.webtrends.harness.component.akkahttp._
 import com.webtrends.harness.component.messages.StatusRequest
 import com.webtrends.harness.component.{ComponentHelper, ComponentRequest, StopComponent}
 import com.webtrends.harness.health._

--- a/src/main/scala/com/webtrends/harness/component/akkahttp/routes/InternalAkkaHttpRouteContainer.scala
+++ b/src/main/scala/com/webtrends/harness/component/akkahttp/routes/InternalAkkaHttpRouteContainer.scala
@@ -1,0 +1,14 @@
+package com.webtrends.harness.component.akkahttp.routes
+
+import java.util.Collections
+
+import akka.http.scaladsl.server.Route
+
+import scala.collection.JavaConversions._
+
+object InternalAkkaHttpRouteContainer {
+  private val routes = Collections.synchronizedSet[Route](new java.util.HashSet[Route]())
+  def isEmpty = routes.isEmpty
+  def addRoute(r: Route) = routes.add(r)
+  def getRoutes = routes.toSet
+}

--- a/src/main/scala/com/webtrends/harness/component/akkahttp/routes/WebsocketAkkaHttpActor.scala
+++ b/src/main/scala/com/webtrends/harness/component/akkahttp/routes/WebsocketAkkaHttpActor.scala
@@ -1,0 +1,25 @@
+package com.webtrends.harness.component.akkahttp.routes
+
+import akka.actor.Props
+import akka.http.scaladsl.server.Directives.reject
+import akka.http.scaladsl.settings.ServerSettings
+import akka.http.scaladsl.server.Directives._
+import com.webtrends.harness.component.akkahttp.WebsocketAkkaHttpSettings
+
+object WebsocketAkkaHttpActor {
+  def props(settings: WebsocketAkkaHttpSettings) = {
+    Props(classOf[WebsocketAkkaHttpActor], settings.port, settings.interface, settings.serverSettings)
+  }
+}
+
+class WebsocketAkkaHttpActor(port: Int, interface: String, settings: ServerSettings)
+  extends ExternalAkkaHttpActor(port, interface, settings) {
+  override def serverName = "akka-http websocket-server"
+
+  override def routes = if (WebsocketAkkaHttpRouteContainer.isEmpty) {
+    log.error("no routes defined")
+    reject()
+  } else {
+    WebsocketAkkaHttpRouteContainer.getRoutes.reduceLeft(_ ~ _)
+  }
+}

--- a/src/main/scala/com/webtrends/harness/component/akkahttp/routes/WebsocketAkkaHttpRouteContainer.scala
+++ b/src/main/scala/com/webtrends/harness/component/akkahttp/routes/WebsocketAkkaHttpRouteContainer.scala
@@ -1,4 +1,4 @@
-package com.webtrends.harness.component.akkahttp
+package com.webtrends.harness.component.akkahttp.routes
 
 import java.util.Collections
 
@@ -6,9 +6,10 @@ import akka.http.scaladsl.server.Route
 
 import scala.collection.JavaConversions._
 
-object InternalAkkaHttpRouteContainer {
-  private val routes = Collections.synchronizedSet[Route](new java.util.HashSet[Route]())
+object WebsocketAkkaHttpRouteContainer {
+  private val routes = Collections.synchronizedSet[Route](new java.util.LinkedHashSet[Route]())
   def isEmpty = routes.isEmpty
   def addRoute(r: Route) = routes.add(r)
   def getRoutes = routes.toSet
 }
+

--- a/src/main/scala/com/webtrends/harness/component/akkahttp/websocket/AkkaHttpWebsocket.scala
+++ b/src/main/scala/com/webtrends/harness/component/akkahttp/websocket/AkkaHttpWebsocket.scala
@@ -9,7 +9,8 @@ import akka.stream.scaladsl.{Flow, Sink, Source}
 import akka.stream.{ActorMaterializer, OverflowStrategy}
 import com.webtrends.harness.app.HActor
 import com.webtrends.harness.command.{Command, CommandBean}
-import com.webtrends.harness.component.akkahttp.{AkkaHttpCommandResponse, ExternalAkkaHttpRouteContainer}
+import com.webtrends.harness.component.akkahttp.AkkaHttpCommandResponse
+import com.webtrends.harness.component.akkahttp.routes.WebsocketAkkaHttpRouteContainer
 
 import scala.concurrent.Future
 
@@ -119,5 +120,5 @@ trait AkkaHttpWebsocket extends Command with HActor {
   }
 
   log.info(s"Adding Websocket on path $path to routes")
-  ExternalAkkaHttpRouteContainer.addRoute(webSocketRoute)
+  WebsocketAkkaHttpRouteContainer.addRoute(webSocketRoute)
 }

--- a/src/test/scala/com/webtrends/harness/component/akkahttp/AkkaHttpInternalRouteTest.scala
+++ b/src/test/scala/com/webtrends/harness/component/akkahttp/AkkaHttpInternalRouteTest.scala
@@ -1,11 +1,11 @@
 package com.webtrends.harness.component.akkahttp
 
 import akka.http.scaladsl.testkit.ScalatestRouteTest
-import com.webtrends.harness.command.{BaseCommand, BaseCommandResponse, CommandBean}
+import com.webtrends.harness.command.{BaseCommandResponse, CommandBean}
 import com.webtrends.harness.component.akkahttp.directives.AkkaHttpInternal
 import com.webtrends.harness.component.akkahttp.methods.AkkaHttpGet
+import com.webtrends.harness.component.akkahttp.routes.{ExternalAkkaHttpRouteContainer, InternalAkkaHttpRouteContainer}
 import com.webtrends.harness.component.akkahttp.util.TestBaseCommand
-import com.webtrends.harness.logging.Logger
 import org.scalatest.prop.PropertyChecks
 import org.scalatest.{FunSuite, MustMatchers}
 

--- a/src/test/scala/com/webtrends/harness/component/akkahttp/AkkaHttpWebsocketTest.scala
+++ b/src/test/scala/com/webtrends/harness/component/akkahttp/AkkaHttpWebsocketTest.scala
@@ -10,6 +10,7 @@ import akka.stream.ActorMaterializer
 import akka.stream.scaladsl.{Sink, Source}
 import akka.util.{ByteString, Timeout}
 import com.webtrends.harness.command.CommandBean
+import com.webtrends.harness.component.akkahttp.routes.WebsocketAkkaHttpRouteContainer
 import com.webtrends.harness.component.akkahttp.websocket.AkkaHttpWebsocket
 import org.scalatest.{MustMatchers, WordSpecLike}
 
@@ -85,7 +86,7 @@ class AkkaHttpWebsocketTest extends WordSpecLike
   Await.result(system.actorSelection(twsActorLong.path).resolveOne(), Duration("5 seconds"))
   Await.result(system.actorSelection(twsActorStream.path).resolveOne(), Duration("5 seconds"))
   Await.result(system.actorSelection(twsActorClose.path).resolveOne(), Duration("5 seconds"))
-  val routes = ExternalAkkaHttpRouteContainer.getRoutes.reduceLeft(_ ~ _)
+  val routes = WebsocketAkkaHttpRouteContainer.getRoutes.reduceLeft(_ ~ _)
   // End of setup
 
   "AkkaHttpWebsocket" should {

--- a/src/test/scala/com/webtrends/harness/component/akkahttp/directives/AkkaHttpMultiTest.scala
+++ b/src/test/scala/com/webtrends/harness/component/akkahttp/directives/AkkaHttpMultiTest.scala
@@ -10,11 +10,12 @@ import akka.http.scaladsl.testkit.ScalatestRouteTest
 import com.webtrends.harness.command.{BaseCommand, BaseCommandResponse, CommandBean, CommandResponse}
 import com.webtrends.harness.component.akkahttp.util.TestEntity
 import com.webtrends.harness.component.akkahttp._
+import com.webtrends.harness.component.akkahttp.methods.{AkkaHttpMulti, Endpoint}
 import com.webtrends.harness.logging.Logger
 import org.scalatest.prop.PropertyChecks
 import org.scalatest.{FunSuite, MustMatchers}
-import scala.collection.JavaConversions._
 
+import scala.collection.JavaConversions._
 import scala.concurrent.Future
 
 
@@ -43,13 +44,13 @@ class AkkaHttpMultiTest extends FunSuite with PropertyChecks with MustMatchers w
             Future.successful(CommandResponse(Some("getted2".asInstanceOf[T])))
           case ("two/strings/$count", HttpMethods.GET) =>
             Future.successful(CommandResponse(bean.get.getValue[Holder1](AkkaHttpBase.Segments).map(holder =>
-              holder.i1.asInstanceOf[T])))
+              holder._1.asInstanceOf[T])))
           case ("separated/$arg1/args/$arg2", HttpMethods.GET) =>
             Future.successful(CommandResponse(bean.get.getValue[Holder2](AkkaHttpBase.Segments).map(holder =>
-              (holder.i1 + holder.i2).asInstanceOf[T])))
+              (holder._1 + holder._2).asInstanceOf[T])))
           case ("one/$a1/two/$a2/three/$3/four", HttpMethods.GET) =>
             Future.successful(CommandResponse(bean.get.getValue[Holder3](AkkaHttpBase.Segments).map(holder =>
-              (holder.i1 + holder.i2 + holder.i3).asInstanceOf[T])))
+              (holder._1 + holder._2 + holder._3).asInstanceOf[T])))
         }
       }
 
@@ -107,12 +108,12 @@ class AkkaHttpMultiTest extends FunSuite with PropertyChecks with MustMatchers w
               Future.successful(CommandResponse(Some("getted2".asInstanceOf[T])))
             case ("two/$arg", HttpMethods.GET) =>
               Future.successful(CommandResponse(bean.get.getValue[Holder1](AkkaHttpBase.Segments).map(holder =>
-                holder.i1.asInstanceOf[T])))
+                holder._1.asInstanceOf[T])))
             case ("one/strings", HttpMethods.GET) =>
               Future.successful(CommandResponse(Some("getted1".asInstanceOf[T])))
             case ("one/$arg", HttpMethods.GET) =>
               Future.successful(CommandResponse(bean.get.getValue[Holder1](AkkaHttpBase.Segments).map(holder =>
-                holder.i1.asInstanceOf[T])))
+                holder._1.asInstanceOf[T])))
           }
         }
 


### PR DESCRIPTION
* Support for websockets on their own server
* Multi classes will now put their URI parameters onto the bean directly just like spray did
* Major version bump due to package movement and AkkaHttpMulti now returning actual Tuple objects