### PR TITLE
Kill akka specific command bean and entity

### DIFF
--- a/src/main/scala/com/webtrends/harness/component/akkahttp/AkkaHttpBase.scala
+++ b/src/main/scala/com/webtrends/harness/component/akkahttp/AkkaHttpBase.scala
@@ -29,9 +29,6 @@ case class AkkaHttpException[T](entity: T,
                                 statusCode: StatusCode = InternalServerError,
                                 headers: immutable.Seq[HttpHeader] = immutable.Seq.empty,
                                 marshaller: Option[ToEntityMarshaller[T]] = None) extends Throwable(entity.toString)
-
-class AkkaHttpCommandBean() extends CommandBean
-
 trait AkkaHttpParameters
 trait AkkaHttpPathSegments
 trait AkkaHttpAuth

--- a/src/main/scala/com/webtrends/harness/component/akkahttp/directives/AkkaHttpEntity.scala
+++ b/src/main/scala/com/webtrends/harness/component/akkahttp/directives/AkkaHttpEntity.scala
@@ -24,7 +24,7 @@ trait AkkaHttpEntity[EntityT <: AnyRef] extends AkkaHttpBase {
 
   def readEntity(bean: CommandBean): Directive[Unit] = {
     entity(as[EntityT](unmarshaller)).flatMap { entity =>
-      bean.addValue(AkkaHttpEntity.Entity, entity)
+      bean.addValue(CommandBean.KeyEntity, entity)
       pass
     } recover { rejections =>
       if (rejections.size == 1 && rejections.head.isInstanceOf[RequestEntityExpectedRejection]) {
@@ -36,10 +36,6 @@ trait AkkaHttpEntity[EntityT <: AnyRef] extends AkkaHttpBase {
   // Can use to get the entity that was unmarshalled and put on the bean, will be None if
   // empty payload was passed
   def getEntity[T](bean: CommandBean): Option[T] = {
-    bean.getValue[T](AkkaHttpEntity.Entity)
+    bean.getValue[T](CommandBean.KeyEntity)
   }
-}
-
-object AkkaHttpEntity {
-  val Entity = "entity"
 }

--- a/src/main/scala/com/webtrends/harness/component/akkahttp/methods/AkkaHttpMulti.scala
+++ b/src/main/scala/com/webtrends/harness/component/akkahttp/methods/AkkaHttpMulti.scala
@@ -116,6 +116,7 @@ trait AkkaHttpMulti extends AkkaHttpBase { this: BaseCommand =>
 
   // Used to set entity, won't need to override
   def maxSizeBytes: Long = 1.024e6.toLong
+  // TODO Consider attempting to cast values to ints before placing onto bean as other frameworks did
   override def beanDirective(bean: CommandBean, url: String = "", method: HttpMethod = HttpMethods.GET): Directive1[CommandBean] = {
     // Grab all segments from the URI and put them directly on the bean
     val segs = bean.getValue[String](AkkaHttpBase.Path).getOrElse("").split("/").filter(_.startsWith("$"))

--- a/src/main/scala/com/webtrends/harness/component/akkahttp/methods/AkkaHttpMulti.scala
+++ b/src/main/scala/com/webtrends/harness/component/akkahttp/methods/AkkaHttpMulti.scala
@@ -41,7 +41,6 @@ trait AkkaHttpMulti extends AkkaHttpBase { this: BaseCommand =>
   def getQueryParams(bean: CommandBean): Map[String, String] =
     bean.getValue[Map[String, String]](AkkaHttpBase.QueryParams).getOrElse(Map.empty[String, String])
 
-  // TODO: Add support for inputs of specific types, instead of treating every segment as a string
   // Method that adds all routes from allPaths
   override def createRoutes() = {
     allPaths.foreach { endpoint =>

--- a/src/main/scala/com/webtrends/harness/component/akkahttp/methods/AkkaHttpMulti.scala
+++ b/src/main/scala/com/webtrends/harness/component/akkahttp/methods/AkkaHttpMulti.scala
@@ -5,6 +5,7 @@ import akka.http.scaladsl.server.Directives.{entity, provide, path => p, _}
 import akka.http.scaladsl.server.{Directive1, PathMatcher, PathMatchers}
 import com.webtrends.harness.command.{BaseCommand, CommandBean}
 import com.webtrends.harness.component.akkahttp._
+import com.webtrends.harness.component.akkahttp.directives.AkkaHttpEntity
 
 /**
   * Use this class to create a command that can handle any number of endpoints with any

--- a/src/test/scala/com/webtrends/harness/component/akkahttp/directives/AkkaHttpEntityTest.scala
+++ b/src/test/scala/com/webtrends/harness/component/akkahttp/directives/AkkaHttpEntityTest.scala
@@ -42,7 +42,7 @@ class AkkaHttpEntityTest extends FunSuite with PropertyChecks with MustMatchers 
         override def addRoute(r: Route): Unit = routes += r
 
         override def execute[T: Manifest](bean: Option[CommandBean]): Future[BaseCommandResponse[T]] = {
-          val e = bean.get(AkkaHttpEntity.Entity).asInstanceOf[TestEntity]
+          val e = bean.get(CommandBean.KeyEntity).asInstanceOf[TestEntity]
           val response = AkkaHttpCommandResponse(Some(e.asInstanceOf[T]))
           Future.successful(response)
         }
@@ -103,7 +103,7 @@ class AkkaHttpEntityTest extends FunSuite with PropertyChecks with MustMatchers 
         override def addRoute(r: Route): Unit = routes += r
 
         override def execute[T: Manifest](bean: Option[CommandBean]): Future[BaseCommandResponse[T]] = {
-          val e = bean.get(AkkaHttpEntity.Entity).asInstanceOf[TestEntity]
+          val e = bean.get(CommandBean.KeyEntity).asInstanceOf[TestEntity]
           val response = AkkaHttpCommandResponse(Some(e.asInstanceOf[T]))
           Future.successful(response)
         }
@@ -132,7 +132,7 @@ class AkkaHttpEntityTest extends FunSuite with PropertyChecks with MustMatchers 
         override def addRoute(r: Route): Unit = routes += r
 
         override def execute[T: Manifest](bean: Option[CommandBean]): Future[BaseCommandResponse[T]] = {
-          val e = bean.get(AkkaHttpEntity.Entity).asInstanceOf[TestEntity]
+          val e = bean.get(CommandBean.KeyEntity).asInstanceOf[TestEntity]
           val response = AkkaHttpCommandResponse(Some(e.asInstanceOf[T]))
           Future.successful(response)
         }
@@ -165,7 +165,7 @@ class AkkaHttpEntityTest extends FunSuite with PropertyChecks with MustMatchers 
         override def addRoute(r: Route): Unit = routes += r
 
         override def execute[T: Manifest](bean: Option[CommandBean]): Future[BaseCommandResponse[T]] = {
-          val e = bean.get(AkkaHttpEntity.Entity).asInstanceOf[TestEntity]
+          val e = bean.get(CommandBean.KeyEntity).asInstanceOf[TestEntity]
           val response = AkkaHttpCommandResponse(Some(e.asInstanceOf[T]))
           Future.successful(response)
         }
@@ -212,7 +212,7 @@ class AkkaHttpEntityTest extends FunSuite with PropertyChecks with MustMatchers 
         override def addRoute(r: Route): Unit = routes += r
 
         override def execute[T: Manifest](bean: Option[CommandBean]): Future[BaseCommandResponse[T]] = {
-          val e = bean.get(AkkaHttpEntity.Entity).asInstanceOf[TestEntity]
+          val e = bean.get(CommandBean.KeyEntity).asInstanceOf[TestEntity]
           Future.failed(AkkaHttpException[ErrorEntity](responseEntity, StatusCodes.OK))
         }
       }


### PR DESCRIPTION
* In favor of more commonly depended-on CommandBean and CommandBean.KeyEntity