### PR TITLE
Add ping healthcheck for External and Internal AkkaHttpActor

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
         <scala.version>${scala.artifact.version}.12</scala.version>
         <akka.version>2.5.4</akka.version>
         <akka.http.version>10.0.10</akka.http.version>
-        <wookiee.core.version>1.3.18</wookiee.core.version>
+        <wookiee.core.version>1.3.19</wookiee.core.version>
     </properties>
 
     <groupId>com.webtrends</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
         <scala.version>${scala.artifact.version}.12</scala.version>
         <akka.version>2.5.4</akka.version>
         <akka.http.version>10.0.10</akka.http.version>
-        <wookiee.core.version>1.3.17</wookiee.core.version>
+        <wookiee.core.version>1.3.18</wookiee.core.version>
     </properties>
 
     <groupId>com.webtrends</groupId>

--- a/src/main/scala/com/webtrends/harness/component/akkahttp/client/SimpleHttpClient.scala
+++ b/src/main/scala/com/webtrends/harness/component/akkahttp/client/SimpleHttpClient.scala
@@ -1,0 +1,33 @@
+package com.webtrends.harness.component.akkahttp.client
+
+import akka.actor.Actor
+import akka.http.scaladsl.Http
+import akka.http.scaladsl.model.{HttpRequest, HttpResponse}
+import akka.stream.ActorMaterializer
+import akka.util.ByteString
+
+import scala.concurrent.{ExecutionContext, Future}
+
+trait SimpleHttpClient { this: Actor =>
+
+  implicit val executionContext: ExecutionContext
+  implicit val materializer = ActorMaterializer()
+
+  private val http = Http(context.system)
+
+  def request(req: HttpRequest): Future[(HttpResponse, Array[Byte])] = {
+    http.singleRequest(req).flatMap { response =>
+      response.entity.dataBytes.runFold(ByteString(""))(_ ++ _).map(bs => (response, bs.toArray))
+    }
+  }
+
+  def requestAs[T](req: HttpRequest, mapper: Array[Byte] => T): Future[(HttpResponse, T)] = {
+    request(req).map { case (response, bytes) =>
+      (response, mapper(bytes))
+    }
+  }
+
+  def requestAsString(req: HttpRequest): Future[(HttpResponse, String)] = {
+    requestAs[String](req, b => new String(b, "utf-8"))
+  }
+}

--- a/src/main/scala/com/webtrends/harness/component/akkahttp/client/SimpleHttpClient.scala
+++ b/src/main/scala/com/webtrends/harness/component/akkahttp/client/SimpleHttpClient.scala
@@ -2,13 +2,14 @@ package com.webtrends.harness.component.akkahttp.client
 
 import akka.actor.Actor
 import akka.http.scaladsl.Http
-import akka.http.scaladsl.model.{HttpRequest, HttpResponse}
+import akka.http.scaladsl.model.{HttpMethods, HttpRequest, HttpResponse, StatusCodes}
 import akka.stream.ActorMaterializer
 import akka.util.ByteString
+import com.webtrends.harness.logging.ActorLoggingAdapter
 
 import scala.concurrent.{ExecutionContext, Future}
 
-trait SimpleHttpClient { this: Actor =>
+trait SimpleHttpClient extends ActorLoggingAdapter { this: Actor =>
 
   implicit val executionContext: ExecutionContext
   implicit val materializer = ActorMaterializer()
@@ -29,5 +30,17 @@ trait SimpleHttpClient { this: Actor =>
 
   def requestAsString(req: HttpRequest): Future[(HttpResponse, String)] = {
     requestAs[String](req, b => new String(b, "utf-8"))
+  }
+
+  def getPing(url: String) : Future[Boolean] = {
+    val response = requestAsString(HttpRequest(HttpMethods.GET, url))
+
+    response.map {
+      case (response,body) if response.status == StatusCodes.Success =>
+        body.startsWith("pong")
+      case (response,body) =>
+        log.error(s"Unexpected response from ping check with status ${response.status}: $body")
+        false
+    }
   }
 }

--- a/src/main/scala/com/webtrends/harness/component/akkahttp/routes/ExternalAkkaHttpActor.scala
+++ b/src/main/scala/com/webtrends/harness/component/akkahttp/routes/ExternalAkkaHttpActor.scala
@@ -2,6 +2,7 @@ package com.webtrends.harness.component.akkahttp.routes
 
 import akka.actor.Props
 import akka.http.scaladsl.Http
+import akka.http.scaladsl.model.{HttpMethods, HttpRequest, StatusCodes}
 import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server.RouteResult
 import akka.http.scaladsl.settings.ServerSettings
@@ -10,7 +11,11 @@ import akka.stream.scaladsl.Sink
 import com.webtrends.harness.app.HActor
 import com.webtrends.harness.component.StopComponent
 import com.webtrends.harness.component.akkahttp.ExternalAkkaHttpSettings
-
+import com.webtrends.harness.component.akkahttp.client.SimpleHttpClient
+import com.webtrends.harness.health.{ComponentState, HealthComponent}
+import org.joda.time.{DateTime, DateTimeZone}
+import com.webtrends.harness.utils.FutureExtensions._
+import scala.concurrent.Future
 import scala.util.{Failure, Success}
 
 object ExternalAkkaHttpActor {
@@ -19,13 +24,23 @@ object ExternalAkkaHttpActor {
   }
 }
 
-class ExternalAkkaHttpActor(port: Int, interface: String, settings: ServerSettings) extends HActor {
+class ExternalAkkaHttpActor(port: Int, interface: String, settings: ServerSettings) extends HActor with SimpleHttpClient {
   implicit val system = context.system
-  implicit val executionContext = context.dispatcher
-  implicit val materializer = ActorMaterializer()
+  override implicit val executionContext = context.dispatcher
+  override implicit val materializer = ActorMaterializer()
 
   def serverName = "akka-http external-server"
   val serverSource = Http().bind(interface, port, settings = settings)
+
+  val baseRoutes =
+    get {
+      path("favicon.ico") {
+        complete(StatusCodes.NoContent)
+      } ~
+        path("ping") {
+          complete(s"pong: ${new DateTime(System.currentTimeMillis(), DateTimeZone.UTC)}")
+        }
+    }
 
   val bindingFuture = serverSource
     .to(Sink.foreach { conn => conn.handleWith(RouteResult.route2HandlerFlow(routes)) })
@@ -44,11 +59,33 @@ class ExternalAkkaHttpActor(port: Int, interface: String, settings: ServerSettin
     log.error("no routes defined")
     reject()
   } else {
-    ExternalAkkaHttpRouteContainer.getRoutes.reduceLeft(_ ~ _)
+    ExternalAkkaHttpRouteContainer.getRoutes.foldLeft(baseRoutes)(_ ~ _)
+      //.reduceLeft(_ ~ _)
   }
 
   override def receive = super.receive orElse {
     case AkkaHttpUnbind => unbind
     case StopComponent => unbind
+  }
+/*
+  override def getHealth : Future[HealthComponent] = {
+      getPing.mapAll {
+        case Success(_) =>
+          HealthComponent(self.path.toString, ComponentState.NORMAL, "Healthy")
+        case Failure(_) =>
+          HealthComponent(self.path.toString, ComponentState.CRITICAL, "Failed to ping server.")
+      }
+  }
+*/
+  def getPing : Future[Boolean] = {
+    val response = requestAsString(HttpRequest(HttpMethods.GET, s"http://$interface:$port/ping"))
+
+    response.map {
+      case (response,body) if response.status == StatusCodes.Success =>
+        body.startsWith("pong")
+      case (response,body) =>
+        log.error(s"Unexpected response from ping check with status ${response.status}: $body")
+        false
+    }
   }
 }

--- a/src/main/scala/com/webtrends/harness/component/akkahttp/routes/ExternalAkkaHttpActor.scala
+++ b/src/main/scala/com/webtrends/harness/component/akkahttp/routes/ExternalAkkaHttpActor.scala
@@ -38,9 +38,9 @@ class ExternalAkkaHttpActor(port: Int, interface: String, settings: ServerSettin
       path("favicon.ico") {
         complete(StatusCodes.NoContent)
       } ~
-        path("ping") {
-          complete(s"pong: ${new DateTime(System.currentTimeMillis(), DateTimeZone.UTC)}")
-        }
+      path("ping") {
+        complete(s"pong: ${new DateTime(System.currentTimeMillis(), DateTimeZone.UTC)}")
+      }
     }
 
   val bindingFuture = serverSource

--- a/src/main/scala/com/webtrends/harness/component/akkahttp/routes/InternalAkkaHttpActor.scala
+++ b/src/main/scala/com/webtrends/harness/component/akkahttp/routes/InternalAkkaHttpActor.scala
@@ -147,9 +147,6 @@ class InternalAkkaHttpActor(port: Int, interface: String, settings: ServerSettin
     case StopComponent => unbind
   }
 
-  // This should probably be overriden to get some custom information about the health of this actor
-  override protected def getHealth: Future[HealthComponent] = super.getHealth
-
   override def checkHealth : Future[HealthComponent] = {
     getPing(pingUrl).mapAll {
       case Success(_) =>

--- a/src/main/scala/com/webtrends/harness/component/akkahttp/routes/InternalAkkaHttpActor.scala
+++ b/src/main/scala/com/webtrends/harness/component/akkahttp/routes/InternalAkkaHttpActor.scala
@@ -15,6 +15,7 @@ import akka.stream.scaladsl.Sink
 import com.webtrends.harness.HarnessConstants
 import com.webtrends.harness.app.{HActor, Harness}
 import com.webtrends.harness.component.akkahttp._
+import com.webtrends.harness.component.akkahttp.client.SimpleHttpClient
 import com.webtrends.harness.component.messages.StatusRequest
 import com.webtrends.harness.component.{ComponentHelper, ComponentRequest, StopComponent}
 import com.webtrends.harness.health._
@@ -26,7 +27,7 @@ import de.heikoseeberger.akkahttpjson4s.Json4sSupport._
 import org.joda.time.{DateTime, DateTimeZone}
 import org.json4s.ext.{EnumNameSerializer, JodaTimeSerializers}
 import org.json4s.{DefaultFormats, JValue, jackson}
-
+import com.webtrends.harness.utils.FutureExtensions._
 import scala.concurrent.Future
 import scala.util.{Failure, Success}
 
@@ -39,14 +40,16 @@ object InternalAkkaHttpActor {
 case class AkkaHttpUnbind()
 
 class InternalAkkaHttpActor(port: Int, interface: String, settings: ServerSettings) extends HActor
-  with ComponentHelper {
+  with ComponentHelper
+  with SimpleHttpClient {
   implicit val system = context.system
   implicit val executionContext = context.dispatcher
-  implicit val materializer = ActorMaterializer()
+  override implicit val materializer = ActorMaterializer()
   implicit val serialization = jackson.Serialization
   implicit val formats       = (DefaultFormats ++ JodaTimeSerializers.all) + new EnumNameSerializer(ComponentState)
 
   val serverSource = Http().bind(interface, port, settings = settings)
+  val pingUrl = s"http://$interface:$port/ping"
 
   val healthActor = system.actorSelection(HarnessConstants.HealthFullName)
   val serviceActor = system.actorSelection(HarnessConstants.ServicesFullName)
@@ -146,4 +149,14 @@ class InternalAkkaHttpActor(port: Int, interface: String, settings: ServerSettin
 
   // This should probably be overriden to get some custom information about the health of this actor
   override protected def getHealth: Future[HealthComponent] = super.getHealth
+
+  override def checkHealth : Future[HealthComponent] = {
+    getPing(pingUrl).mapAll {
+      case Success(_) =>
+        HealthComponent(self.path.toString, ComponentState.NORMAL, s"Healthy: Ping to $pingUrl.")
+      case Failure(_) =>
+        HealthComponent(self.path.toString, ComponentState.CRITICAL, s"Failed to ping server at $pingUrl.")
+    }
+  }
+
 }


### PR DESCRIPTION
Added SimpleHttpClient to do get requests via Akka Http Client
Added base routes to ExternalAkkaHttpActor for favicon.ico and ping
Added checkHealth to Internal and External AkkaHttpActors to hit ping endpoint via the Http Client.
