### PR TITLE
Add counter for open websocket actors

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -127,6 +127,17 @@
             <version>1.13.4</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.webtrends</groupId>
+            <artifactId>wookiee-metrics</artifactId>
+            <version>2.5.3</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.scalatest</groupId>
+                    <artifactId>scalatest_${scala.version}</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/scala/com/webtrends/harness/component/akkahttp/AkkaHttpBase.scala
+++ b/src/main/scala/com/webtrends/harness/component/akkahttp/AkkaHttpBase.scala
@@ -161,6 +161,8 @@ object AkkaHttpBase {
   val QueryParams = "queryParams"
   val RequestHeaders = "requestHeaders"
 
+  val MetricsPrefix = "wookiee.akka-http"
+
   val formats: Formats = DefaultFormats ++ JodaTimeSerializers.all
   val serialization = jackson.Serialization
 

--- a/src/test/scala/com/webtrends/harness/component/akkahttp/AkkaHttpWebsocketTest.scala
+++ b/src/test/scala/com/webtrends/harness/component/akkahttp/AkkaHttpWebsocketTest.scala
@@ -29,6 +29,11 @@ class TestWebsocket extends AkkaHttpWebsocket {
   }
 
   override def commandName = "TestWebsocket"
+
+  override def preStart() = {
+    super.preStart()
+    ClosedObject.metricName = openSocketGauge.name
+  }
 }
 
 class TestWebsocketExtra extends AkkaHttpWebsocket {
@@ -114,6 +119,7 @@ class TestWebsocketKeepAlive extends AkkaHttpWebsocket {
 
 object ClosedObject {
   @volatile var closed = false
+  @volatile var metricName = ""
 }
 
 class AkkaHttpWebsocketTest extends WordSpecLike
@@ -158,6 +164,8 @@ class AkkaHttpWebsocketTest extends WordSpecLike
           wsClient.sendCompletion()
           wsClient.expectCompletion()
         }
+
+      ClosedObject.metricName mustEqual "wookiee.akka-http.websocket.greeter-$var1.open-count"
     }
 
     "be able to send back data with a TextMessage" in {


### PR DESCRIPTION
* Will allow to track stale websockets and see if it's an akka-http issue
* Useful for seeing how many WS connections are open regardless