### PR TITLE
Changed getUserId to getAccessLogId

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     </properties>
     <groupId>com.webtrends</groupId>
     <artifactId>wookiee-akka-http_2.11</artifactId>
-    <version>1.5-SNAPSHOT</version>
+    <version>1.6-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>Component: Akka Http</name>
     <repositories>

--- a/src/main/scala/com/webtrends/harness/component/akkahttp/logging/AccessLog.scala
+++ b/src/main/scala/com/webtrends/harness/component/akkahttp/logging/AccessLog.scala
@@ -11,8 +11,10 @@ trait AccessLog  {
 
   val accessLog = Logger("AccessLog")
 
-  // Override to obtain the userId
-  def getUserId(bean: CommandBean): Option[String] = {
+  // Override to obtain the id
+  // id is no longer limited to user, with oauth or other authentication/authorization there are other ids to consider.
+  // Like client id.
+  def getAccessLogId(bean: CommandBean): Option[String] = {
     None
   }
 
@@ -20,7 +22,7 @@ trait AccessLog  {
 
     // modify the logback.xml file to write the "AccessLog" entries to a file without all of the prefix information
     try {
-      val userId: String = getUserId(bean).getOrElse("-")
+      val id: String = getAccessLogId(bean).getOrElse("-")
       val status: String = statusCode.map(sc => sc.intValue.toString).getOrElse("-")
       val responseTimestamp: Long = System.currentTimeMillis()
       val requestTimestamp: Long = bean.getValue[Long](TimeOfRequest).getOrElse(responseTimestamp)
@@ -31,7 +33,7 @@ trait AccessLog  {
 
           %h – The IP address of the server.
           %l – The identity of the client determined by identd on the client’s machine. Will return a hyphen (-) if this information is not available.
-          %u – The userid of the client if the request was authenticated.
+          %u – The id of the client if the request was authenticated.
           %t – The time that the request was received, in UTC
           \"%r\" – The request line that includes the HTTP method used, the requested resource path, and the HTTP protocol that the client used.
           %>s – The status code that the server sends back to the client.
@@ -40,7 +42,7 @@ trait AccessLog  {
 
           see https://httpd.apache.org/docs/2.4/logs.html
       */
-      accessLog.info( s"""${AccessLog.host} - $userId [$requestTime] "${request.method.value} ${request.uri} ${request.protocol.value}" $status - $elapsedTime""")
+      accessLog.info( s"""${AccessLog.host} - $id [$requestTime] "${request.method.value} ${request.uri} ${request.protocol.value}" $status - $elapsedTime""")
     } catch {
       case e: Exception =>
         accessLog.error("Could not construct access log", e)


### PR DESCRIPTION
In the changing world of authentication/authorization the "user" becomes increasingly rare.