### PR TITLE
Bumps akka and fixes build issues

### DIFF
--- a/examples/akka-http-service/pom.xml
+++ b/examples/akka-http-service/pom.xml
@@ -20,10 +20,10 @@
                       http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <properties>
+        <akka.version>2.6.5</akka.version>
+        <akka.http.version>10.1.12</akka.http.version>
         <scala.version>2.12.10</scala.version>
         <scala.artifact.version>2.12</scala.artifact.version>
-        <akka.http.version>10.1.1</akka.http.version>
-        <akka.stream.version>2.5.23</akka.stream.version>
         <scalatest.version>3.0.8</scalatest.version>
     </properties>
 
@@ -42,13 +42,6 @@
     <artifactId>akka-http-service</artifactId>
     <version>1.0-SNAPSHOT</version>
 
-    <parent>
-        <groupId>com.webtrends</groupId>
-        <artifactId>wookiee-akka-http_2.12</artifactId>
-        <version>2.0-SNAPSHOT</version>
-        <relativePath>../../pom.xml</relativePath>
-    </parent>
-
     <repositories>
         <repository>
             <id>JFrog</id>
@@ -58,9 +51,9 @@
 
     <dependencies>
         <dependency>
-            <groupId>${parent.groupId}</groupId>
+            <groupId>com.webtrends</groupId>
             <artifactId>wookiee-akka-http_2.12</artifactId>
-            <version>${parent.version}</version>
+            <version>2.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>com.typesafe.akka</groupId>
@@ -90,24 +83,14 @@
         </dependency>
         <dependency>
             <groupId>com.typesafe.akka</groupId>
-            <artifactId>akka-stream_${scala.artifact.version}</artifactId>
-            <version>${akka.stream.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>com.typesafe.akka</groupId>
             <artifactId>akka-http-testkit_${scala.artifact.version}</artifactId>
             <version>${akka.http.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.typesafe.akka</groupId>
-            <artifactId>akka-actor_${scala.artifact.version}</artifactId>
-            <version>2.5.23</version>
-        </dependency>
-        <dependency>
-            <groupId>com.typesafe.akka</groupId>
             <artifactId>akka-stream-testkit_${scala.artifact.version}</artifactId>
-            <version>${akka.stream.version}</version>
+            <version>${akka.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -143,13 +126,6 @@
             <artifactId>logback-classic</artifactId>
             <version>1.2.3</version>
         </dependency>
-
-        <dependency>
-            <groupId>com.typesafe.akka</groupId>
-            <artifactId>akka-remote_${scala.artifact.version}</artifactId>
-            <version>2.5.23</version>
-        </dependency>
-
     </dependencies>
 
     <build>

--- a/examples/akka-http-service/readme.md
+++ b/examples/akka-http-service/readme.md
@@ -3,27 +3,27 @@ A one line Service!! This is an example of how easy it is to get your project ru
 on Wookiee. This one line service can be run just like it would be on a server.
 
 ## Building
-First build parent wookiee project by navigating to ../wookiee and running
+First build parent wookiee project by navigating to ../wookiee-akka-http and running
 > mvn clean install
 
-This will get the SNAPSHOT of Wookiee into your local repo.
+This will get the SNAPSHOT of Wookiee-Akka-Http into your local repo.
 
-Then build Basic Service and its tests with the same command in ../examples/basic-service
+Then build Basic Service and its tests with the same command in ../examples/akka-http-service
 > mvn clean install 
 
 ## Running Service Locally
 If you want to see what it looks like to have a Wookiee service running, then open
 this repo up in IntelliJ Idea and do the following...
 
-* Right click on pom.xml in ../examples/basic-service and click "Add as Maven Project"
+* Right click on pom.xml in ../examples/akka-http-service and click "Add as Maven Project"
     * This adds the example repo and its code as a module to your project
 * Edit Run/Debug Configurations
 * Hit the "+" and select Application
 * Input the Following:
     * Main Class: com.webtrends.harness.app.HarnessService
     * VM Options: -Dconfig.file=src/main/resources/application.conf -Dlogback.configurationFile=src/main/resources/logback.xml
-    * Working Directory: ${your path to ../wookiee/examples/basic-service}
-    * Use Classpath of Module: basic-service
+    * Working Directory: ${your path to ../wookiee-akka-http/examples/akka-http-service}
+    * Use Classpath of Module: akka-http-service
 * Press "OK"
 
 You can then take advantage of Wookiee's health checks:

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
         <release.type>SNAPSHOT</release.type>
         <build>${build.number}</build>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <akka.stream.version>2.5.23</akka.stream.version>
+        <akka.stream.version>2.6.5</akka.stream.version>
         <akka.http.version>10.1.12</akka.http.version>
         <wookiee.core.version>2.0.0-RC2</wookiee.core.version>
         <wookiee-metrics.version>2.5.16</wookiee-metrics.version>


### PR DESCRIPTION
Previous use of <parent> by the example server never worked. Project parents cannot be the primary jar creator.